### PR TITLE
fix type definitions of startColor and endColor

### DIFF
--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -61,8 +61,8 @@ declare namespace PIXI.particles {
 		public startScale:number;
 		public endScale:number;
 		public minimumScaleMultiplier:number;
-		public startColor:[number, number, number];
-		public endColor:[number, number, number];
+		public startColor:number[];
+		public endColor:number[];
 		public minLifetime:number;
 		public maxLifetime:number;
 		public minStartRotation:number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,8 +62,8 @@ declare namespace particles {
 		public startScale:number;
 		public endScale:number;
 		public minimumScaleMultiplier:number;
-		public startColor:[number, number, number];
-		public endColor:[number, number, number];
+		public startColor:number[];
+		public endColor:number[];
 		public minLifetime:number;
 		public maxLifetime:number;
 		public minStartRotation:number;
@@ -143,8 +143,8 @@ declare namespace particles {
 		public maxSpeed:number;
 		public startScale:number;
 		public endScale:number;
-		public startColor:[number, number, number];
-		public endColor:[number, number, number];
+		public startColor:number[];
+		public endColor:number[];
 		
 		/** Note that for Particle, the parameter is an array of strings or PIXI.Textures, and an array of Textures is returned. */
 		public static parseArt(art:any):any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -143,8 +143,8 @@ declare namespace particles {
 		public maxSpeed:number;
 		public startScale:number;
 		public endScale:number;
-		public startColor:number[];
-		public endColor:number[];
+		public startColor:[number, number, number];
+		public endColor:[number, number, number];
 		
 		/** Note that for Particle, the parameter is an array of strings or PIXI.Textures, and an array of Textures is returned. */
 		public static parseArt(art:any):any;


### PR DESCRIPTION
This pull request prevents this error from happening:

```
Type 'number[]' is not assignable to type '[number, number, number]'.
```

It occurs when trying to associate `startColor` or `endColor` to the result of `particles.ParticleUtils.hexToRGB(...)`, which returns a explicit `[number, number, number]` instead of `number[]`.