### PR TITLE
When time is reversed an age drops below 0 the particle is killed

### DIFF
--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -355,7 +355,7 @@ export default class Particle extends Sprite
 		//increase age
 		this.age += delta;
 		//recycle particle if it is too old
-		if(this.age >= this.maxLife)
+		if(this.age >= this.maxLife || this.age < 0)
 		{
 			this.kill();
 			return -1;


### PR DESCRIPTION
When time is reversed weird behaviour is observed by the particles when the age drops below 0. Granted time should never be reversed however since the consumer of the library can manually control the update method it's possible for them to play time backwards. This is merely a safety catch so that when that does happen the particles whom's age shows they haven't been born yet are killed off. This stops the weird behaviour from occurring.

Once time returns to normal (ie. forward) then new particles are created in place of those that were killed during the reversal of time.
