### PR TITLE
Negative deltas will no longer effect the spawn duration

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -845,7 +845,7 @@ export default class Emitter
 		if (this._emit)
 		{
 			//decrease spawn timer
-			this._spawnTimer -=  Math.max(delta, 0);
+			this._spawnTimer -=  delta < 0 ? 0 : delta;
 			//while _spawnTimer < 0, we have particles to spawn
 			while(this._spawnTimer <= 0)
 			{

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -845,7 +845,7 @@ export default class Emitter
 		if (this._emit)
 		{
 			//decrease spawn timer
-			this._spawnTimer -= delta;
+			this._spawnTimer -=  Math.max(delta, 0);
 			//while _spawnTimer < 0, we have particles to spawn
 			while(this._spawnTimer <= 0)
 			{


### PR DESCRIPTION
The reversal of time increases the amount of time of the next particle spawn. This means if you reverse time for 2 minutes and then play it forward, it will take 2 minutes before the next particle is spawned. This change means that will no longer be the case. you can reverse time until all particles are killed off and then play forward immediately with no ill effects.