### PR TITLE
emitter life issue fixed

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -823,7 +823,7 @@ export class Emitter
 			while(this._spawnTimer <= 0)
 			{
 				//determine if the emitter should stop spawning
-				if(this._emitterLife > 0)
+				if(this._emitterLife >= 0)
 				{
 					this._emitterLife -= this._frequency;
 					if(this._emitterLife <= 0)


### PR DESCRIPTION
Fixed issue: Despite the docs saying that the emitters will emit infinitely if `emitterLifetime `prop is set to "-1", they will do so if  `emitterLifetime `prop is set to "0" as well.

This also handles the rare case that during emitting `this._emitterLife` can be calculated to be "0".  In which case the emitting can unintentionally become infinite.