### PR TITLE
Replace TravisCI with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+on:
+  push:
+    branches: [ '**' ]
+    tags: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - name: Install npm
+      uses: borales/actions-yarn@v2.3.0
+      with:
+        cmd: install
+    - name: Build
+      uses: borales/actions-yarn@v2.3.0
+      with:
+        cmd: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12
-    - name: Install npm
+    - name: Install Dependencies
       uses: borales/actions-yarn@v2.3.0
       with:
         cmd: install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "12.16.0"
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
-  - export PATH="$HOME/.yarn/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pixi Particles
 
-[![Build Status](https://travis-ci.org/pixijs/pixi-particles.svg)](https://travis-ci.org/pixijs/pixi-particles) [![Dependency Status](https://david-dm.org/pixijs/pixi-particles.svg?style=flat)](https://david-dm.org/pixijs/pixi-particles) [![GitHub version](https://badge.fury.io/gh/pixijs%2Fpixi-particles.svg)](https://github.com/pixijs/pixi-particles/releases/latest)
+[![Build Status](https://github.com/pixijs/pixi-particles/workflows/Build/badge.svg)](https://github.com/pixijs/pixi-particles/actions?query=workflow%3A%22Build%22) [![Dependency Status](https://david-dm.org/pixijs/pixi-particles.svg?style=flat)](https://david-dm.org/pixijs/pixi-particles) [![GitHub version](https://badge.fury.io/gh/pixijs%2Fpixi-particles.svg)](https://github.com/pixijs/pixi-particles/releases/latest)
 
 A particle system library for the [PixiJS](https://github.com/pixijs/pixi.js) library. Also, we created an [interactive particle editor](http://pixijs.github.io/pixi-particles-editor/) to design and preview custom particle emitters which utilitze PixiParticles.
 


### PR DESCRIPTION
GitHub Actions is better and more reliable than Travis. This removes this, which wasn't really being used in any meaningful way anyways.